### PR TITLE
[FIX] website_debranding install error

### DIFF
--- a/website_debranding/views.xml
+++ b/website_debranding/views.xml
@@ -87,7 +87,7 @@ If you try to write with a wide general audience in mind, your story will ring f
     </xpath>
 </template>
 
-
+<delete id="website.show_website_info" model="ir.ui.view"/>
 <delete id="website.info" model="ir.ui.view"/>
 
 </data></openerp>


### PR DESCRIPTION
On install website.info is being delete but website.show_website_info inherits website.info consequently an error in thrown.
This fix removes website.show_website_info before website.info
